### PR TITLE
admin_pages_dev: Modified Laravel Configurations

### DIFF
--- a/.github/workflows/stacksDockerDeployProduction.yaml
+++ b/.github/workflows/stacksDockerDeployProduction.yaml
@@ -23,7 +23,7 @@ jobs:
         working-directory: amp-laravel
         run: |
           echo "APP_KEY=${{ secrets.LARAVEL_APP_KEY }}" > .env.example
-          echo "APP_URL=http://${{ secrets.EC2_HOST_STAGING }}:8000" > .env.example
+          echo "APP_URL=http://${{ secrets.EC2_HOST_PRODUCTION }}:8000" > .env.example
           echo "DB_CONNECTION=mysql" >> .env.example
           echo "DB_HOST=${{ secrets.LARAVEL_DATABASE_HOST }}" >> .env.example
           echo "DB_PORT=${{ secrets.LARAVEL_DATABASE_PORT_NUMBER }}" >> .env.example


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use EC2_HOST_PRODUCTION instead of EC2_HOST_STAGING for APP_URL in the production Docker deployment workflow